### PR TITLE
chore(claude): allow make, go, terraform and gh tool permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,4 +46,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: "--allowedTools Bash(make:*) Bash(go:*) Bash(terraform:*) Bash(gh:*)"


### PR DESCRIPTION
## Summary

- Enables `make`, `go`, `terraform` and `gh` commands in the Claude GitHub Action via `claude_args`
- Allows Claude to run `make generate` to update Terraform documentation after schema changes without hitting permission errors

## Test plan
- [ ] Trigger Claude on an issue that requires `make generate` and verify it completes without permission errors